### PR TITLE
Fixes to object saving format

### DIFF
--- a/lib/salsa_labs/salsa_objects_saver.rb
+++ b/lib/salsa_labs/salsa_objects_saver.rb
@@ -5,7 +5,9 @@ module SalsaLabs
   class SalsaObjectsSaver
     PARAMS_TO_SKIP = ['Date_Created',  # Not allowed to be changed
                       'Last_Modified',  # Not allowed to be changed
-                      'organization_KEY'  # Comes from authorization, but not something we ever set
+                      'organization_KEY',  # Comes from authorization, but not something we ever set
+                      'salsa_deleted',  # Reserved field, should not be modified
+                      'salesforce_id'  # Reserved field, should not be modified
     ].freeze
 
     def initialize(credentials = {})
@@ -16,7 +18,19 @@ module SalsaLabs
       parameters = SalsaLabs::ApiObjectParameterList.new(data)
 
       # Filter out parameters that should not be included
-      filtered_params = parameters.attributes.delete_if { |key, value| PARAMS_TO_SKIP.include?(key) }
+      filtered_params = parameters.attributes.delete_if do |key, value|
+        # foo_boolvalue keys are duplicates of foo keys
+        PARAMS_TO_SKIP.include?(key) || key.end_with?('_boolvalue')
+      end
+
+      # Turn boolean values into 0/1
+      filtered_params.each do |key, value|
+        if value.is_a? TrueClass
+          filtered_params[key] = 1
+        elsif value.is_a? FalseClass
+          filtered_params[key] = 0
+        end
+      end
 
       # 'object' must go first, followed by 'key' if it exists
       ordered_params = {'object' => filtered_params.delete('object')}
@@ -25,9 +39,11 @@ module SalsaLabs
         ordered_params['key'] = key
       end
       ordered_params.merge!(filtered_params)
-        
+
+      # Send the API call to Salsa
       response = parse_response(api_call(ordered_params))
 
+      # Process the response
       if response.css('success')
         return response.css('success').attribute('key').value.to_i
       else

--- a/lib/salsa_labs/salsa_objects_saver.rb
+++ b/lib/salsa_labs/salsa_objects_saver.rb
@@ -11,8 +11,16 @@ module SalsaLabs
     def save(data)
       parameters = SalsaLabs::ApiObjectParameterList.new(data)
       filtered_params = parameters.attributes.delete_if { |key, value| ['Date_Created', 'Last_Modified'].include?(key) }
+
+      # 'object' must go first, followed by 'key' if it exists
+      ordered_params = {'object' => filtered_params.delete('object')}
+      key = filtered_params.delete('key')
+      unless key.nil?
+        ordered_params['key'] = key
+      end
+      ordered_params.merge!(filtered_params)
         
-      response = parse_response(api_call(filtered_params))
+      response = parse_response(api_call(ordered_params))
 
       if response.css('success')
         return response.css('success').attribute('key').value.to_i

--- a/lib/salsa_labs/salsa_objects_saver.rb
+++ b/lib/salsa_labs/salsa_objects_saver.rb
@@ -3,6 +3,10 @@ module SalsaLabs
   # Service object to save an object or a collection of objects to the Salsa Labs API.
   ##
   class SalsaObjectsSaver
+    PARAMS_TO_SKIP = ['Date_Created',  # Not allowed to be changed
+                      'Last_Modified',  # Not allowed to be changed
+                      'organization_KEY'  # Comes from authorization, but not something we ever set
+    ].freeze
 
     def initialize(credentials = {})
       @client = SalsaLabs::ApiClient.new(credentials)
@@ -10,7 +14,9 @@ module SalsaLabs
 
     def save(data)
       parameters = SalsaLabs::ApiObjectParameterList.new(data)
-      filtered_params = parameters.attributes.delete_if { |key, value| ['Date_Created', 'Last_Modified'].include?(key) }
+
+      # Filter out parameters that should not be included
+      filtered_params = parameters.attributes.delete_if { |key, value| PARAMS_TO_SKIP.include?(key) }
 
       # 'object' must go first, followed by 'key' if it exists
       ordered_params = {'object' => filtered_params.delete('object')}

--- a/spec/salsa_labs/salsa_objects_saver_spec.rb
+++ b/spec/salsa_labs/salsa_objects_saver_spec.rb
@@ -14,6 +14,7 @@ describe SalsaLabs::SalsaObjectsSaver do
     let(:attributes) do
       {
         'supporter_key' => '31337',
+        'key' => '31337',
         'organization_key' => '1234',
         'chapter_key' => '90210',
         'title' => 'Mr.',
@@ -36,7 +37,8 @@ describe SalsaLabs::SalsaObjectsSaver do
         'source_tracking_code' => 'foo123',
         'tracking_code' => 'abc123',
         'date_created' => 'Fri Mar 14 2014 14:07:29 GMT-0400 (EDT)',
-        'last_modified' => 'Fri Mar 14 2014 13:54:10 GMT-0400 (EDT)'
+        'last_modified' => 'Fri Mar 14 2014 13:54:10 GMT-0400 (EDT)',
+        'some_custom_field' => 'foo'
       }
     end
     let(:supporter) { SalsaLabs::Supporter.new(attributes) }
@@ -64,7 +66,9 @@ describe SalsaLabs::SalsaObjectsSaver do
         'Source_Details' => 'foo123',
         'Source_Tracking_Code' => 'foo123',
         'Tracking_Code' => 'abc123',
-        'object' => 'supporter'
+        'object' => 'supporter',
+        'key' => '31337',
+        'some_custom_field' => 'foo'
       }
     end
     let(:api_response) do
@@ -76,7 +80,14 @@ describe SalsaLabs::SalsaObjectsSaver do
     end
 
     it 'should call the API, stripping out Last_Modified and Date_Created' do
-      expect(api_client).to receive(:post).with('/save', expected_data).and_return(api_response)
+      expect(api_client).to receive(:post) do |endpoint, params|
+        expect(endpoint).to eq '/save'
+        expect(params).to eq expected_data
+
+        # 'object' and 'key' fields must come first
+        expect(params.keys.first).to eq 'object'
+        expect(params.keys[1]).to eq 'key'
+      end.and_return(api_response)
 
       subject.save(supporter.attributes.update({'object' => 'supporter'}))
     end

--- a/spec/salsa_labs/salsa_objects_saver_spec.rb
+++ b/spec/salsa_labs/salsa_objects_saver_spec.rb
@@ -24,12 +24,15 @@ describe SalsaLabs::SalsaObjectsSaver do
         'suffix' => 'IV',
         'email' => 'johnjacob@example.com',
         'receive_email' => 1,
+        'receive_phone_blasts' => false,
+        'receive_phone_blasts_boolvalue' => false,
         'phone' => '1234567890',
         'street' => '123 Main St',
         'street_2' => 'Apt 404',
         'city' => 'Schnechtady',
         'state' => 'NY',
         'zip' => '12345',
+        'private_zip_plus_4' => '1111',
         'country' => 'USA',
         'source' => 'rspec',
         'status' => 'Active',
@@ -38,6 +41,11 @@ describe SalsaLabs::SalsaObjectsSaver do
         'tracking_code' => 'abc123',
         'date_created' => 'Fri Mar 14 2014 14:07:29 GMT-0400 (EDT)',
         'last_modified' => 'Fri Mar 14 2014 13:54:10 GMT-0400 (EDT)',
+        'district' => 'N/A',
+        'language_code' => 'eng',
+        'salsa_deleted' => false,
+        'salsa_deleted_boolvalue' => false,
+        'text' => 'asdf',
         'some_custom_field' => 'foo'
       }
     end
@@ -53,13 +61,17 @@ describe SalsaLabs::SalsaObjectsSaver do
         'Suffix' => 'IV',
         'Email' => 'johnjacob@example.com',
         'Receive_Email' => 1,
+        'Receive_Phone_Blasts' => 0,
         'Phone' => '1234567890',
         'Street' => '123 Main St',
         'Street_2' => 'Apt 404',
         'City' => 'Schnechtady',
         'State' => 'NY',
         'Zip' => '12345',
+        'PRIVATE_Zip_Plus_4' => '1111',
+        'District' => 'N/A',
         'Country' => 'USA',
+        'Language_Code' => 'eng',
         'Source' => 'rspec',
         'Status' => 'Active',
         'Source_Details' => 'foo123',
@@ -67,6 +79,7 @@ describe SalsaLabs::SalsaObjectsSaver do
         'Tracking_Code' => 'abc123',
         'object' => 'supporter',
         'key' => '31337',
+        'text' => 'asdf',
         'some_custom_field' => 'foo'
       }
     end

--- a/spec/salsa_labs/salsa_objects_saver_spec.rb
+++ b/spec/salsa_labs/salsa_objects_saver_spec.rb
@@ -45,7 +45,6 @@ describe SalsaLabs::SalsaObjectsSaver do
     let(:expected_data) do
       {
         'supporter_KEY' => '31337',
-        'organization_KEY' => '1234',
         'chapter_KEY' => '90210',
         'Title' => 'Mr.',
         'First_Name' => 'John',


### PR DESCRIPTION
This makes several changes to how we call the `/save` endpoint, based on information I've gotten from Salsa support:

- The `object` parameter must be first, followed by `key` if we're updating an existing object
- The `organization_KEY`, `salsa_deleted`, and `salesforce_id` attributes should not be included in `/save` calls
- Attributes ending in `_boolvalue` are duplicates of the same attribute without the `_boolvalue` on the end, so we don't need to include the `_boolvalue` version
- Boolean values should be set as 0 and 1, not true and false