### PR TITLE
Preserve order of parameters in POST requests

### DIFF
--- a/lib/salsa_labs/api_client.rb
+++ b/lib/salsa_labs/api_client.rb
@@ -70,8 +70,7 @@ module SalsaLabs
           faraday.response :logger if ENV['DEBUG']
         end
         
-        # not available until faraday 0.9
-        #Faraday::Utils.default_params_encoder = Faraday::FlatParamsEncoder #do not nest repeated parameters
+        Faraday::Utils.default_params_encoder = Faraday::FlatParamsEncoder #do not nest repeated parameters
         faraday.adapter Faraday.default_adapter
       end
     end

--- a/lib/salsa_labs/api_client.rb
+++ b/lib/salsa_labs/api_client.rb
@@ -87,11 +87,14 @@ module SalsaLabs
     end
 
     def perform_post_request(endpoint, params)
+      # Tell Salsa we want the response back as XML
+      params.update({'xml'=>true})
+
       response = connection.post do |request|
         request.headers['cookie'] = authentication_cookie.to_s
-        params.update({'xml'=>true}) #tell Salsa we want the response back as XML
 
-        request.url(endpoint, params)
+        # Convert the params to array format, so that Faraday will preserve the order of params
+        request.url(endpoint, params.to_a)
       end
 
       raise_if_error!(response)

--- a/spec/salsa_labs/api_client_spec.rb
+++ b/spec/salsa_labs/api_client_spec.rb
@@ -58,6 +58,22 @@ describe SalsaLabs::ApiClient do
     end
   end
 
+  describe '#post' do
+    before :each do
+      allow(api_client).to receive(:authenticated?).and_return(true)
+    end
+
+    it 'should convert hash parameters to array parameters to Faraday, preserving order' do
+      # Q: Why aren't we using Webmock or something for this?
+      # A: Webmock doesn't care about parameter order, so it won't perform this test correctly
+      request = double(body: '', headers: {})
+      expect_any_instance_of(Faraday::Connection).to receive(:post).and_yield(request).and_return(request)
+      expect(request).to receive(:url).with('/foo', [['b', 1], ['a', 2], ['c', 3], ['xml', true]])
+
+      api_client.post('/foo', {'b' => 1, 'a' => 2, 'c' => 3})
+    end
+  end
+
   describe "#fetch" do
     it "returns actions from the Salsa Labs API" do
 


### PR DESCRIPTION
This updates the code we use for making POST requests to Salsa, to ensure the parameters are kept in the same order as the hash keys. This is necessary because the Salsa API requires certain parameters to be in specific orders (e.g. `object` first).

Also included: Uncomment the use of Faraday::FlatParamsEncoder, which was waiting on Faraday 0.9. We're now using Faraday 0.17.3 in agra. GET requests were already effectively using this encoder, and we're not doing anything with nested parameters AFAICT, so this should be fine.